### PR TITLE
Add ifconfig to busybox config requirements in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ enabled:
 
 Then make sure that you have the following Busybox options enabled:
 
+* `CONFIG_IFCONFIG=y` - `ifconfig` ifconfig
 * `CONFIG_UDHCPC=y` - `udhcpc` DHCP Client
 * `CONFIG_UDHCPD=y` - `udhcpd` DHCP Server (optional)
 


### PR DESCRIPTION
I am wondering whether more of the following binaries from the list in VintageNet mix.exs are required: dnsd, ifup, ifdown, chat, pppd (not in busybox config), mknod, wpa_supplicant (not in busybox), ip